### PR TITLE
fix(work): update project name to Ibex Gaming League

### DIFF
--- a/index.html
+++ b/index.html
@@ -460,7 +460,7 @@
           <div class="col-md-2 text-center col-padding animate-box">
             <a data-umami-event="Ibex Gaming Work" href="https://ibexgaming.org/" class="work" style="background-image: url(images/igc-icon.png); background-size: contain;">
               <div class="desc">
-                <h3>Ibex Gaming Circuit</h3>
+                <h3>Ibex Gaming League</h3>
                 <span>Head of Production / Broadcast Operator</span>
                 <span>(Remote & LAN)</span>
               </div>

--- a/index.html
+++ b/index.html
@@ -461,7 +461,7 @@
             <a data-umami-event="Ibex Gaming Work" href="https://ibexgaming.org/" class="work" style="background-image: url(images/igc-icon.png); background-size: contain;">
               <div class="desc">
                 <h3>Ibex Gaming League</h3>
-                <span>Head of Production / Broadcast Operator</span>
+                <span>Head of Broadcast / Broadcast Operator</span>
                 <span>(Remote & LAN)</span>
               </div>
             </a>


### PR DESCRIPTION
Technically, we call you "Head of Broadcast" now – but I did not touch that, so it aligns with other projects, e.g. Switzerlan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Broadcast Work heading to "Ibex Gaming League"
  * Updated role text to "Head of Broadcast / Broadcast Operator" (Remote & LAN indicator unchanged)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->